### PR TITLE
Sync installation script and step-by-step instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
+root
 rootbuild
 rootinstall
-rootsrc
 roottest

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ CMake configuration [required]:
 
 It creates the following directories in the current working directory:
 
-```
+```text
 - root/
 - roottest/
 - rootbuild/
@@ -67,7 +67,8 @@ It creates the following directories in the current working directory:
   produced by CMake. Every time the `launch_build.py` script is launched, it
   creates two separate sub-directories for the current build and installation,
   for example:
-  ```
+
+  ```text
   - rootbuild/
     --> build1/
     --> build2/
@@ -80,7 +81,7 @@ The script launches a CMake build with the appropriate flags, depending on
 either one of the already available modes (see the `m` option) or the flags
 passed via the `c` option. For example:
 
-```
+```bash
 $: python launch_build.py -m relwithdebinfo
 $: python launch_build.py -n mybuild -c="-Dminimal=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo"
 ```

--- a/README.md
+++ b/README.md
@@ -53,13 +53,13 @@ CMake configuration [required]:
 It creates the following directories in the current working directory:
 
 ```
-- rootsrc/
+- root/
 - roottest/
 - rootbuild/
 - rootinstall/
 ```
 
-* `rootsrc` is the directory where the ROOT source resides. If not already
+* `root` is the directory where the ROOT source resides. If not already
   present, it will be downloaded.
 * `roottest` is the directory where the separate testing repository roottest
   source resides. If not already present, it will be downloaded.

--- a/launch_build.py
+++ b/launch_build.py
@@ -12,10 +12,10 @@ def create_directories_if_necessary() -> Iterable[str]:
     root_home = os.path.join(cwd, "root")
     if not os.path.exists(root_home):
         subprocess.run(shlex.split(
-            "git clone https://github.com/root-project/root.git"), check=True)
+            "git clone -o upstream https://github.com/root-project/root.git"), check=True)
     if not os.path.exists(os.path.join(cwd, "roottest")):
         subprocess.run(shlex.split(
-            "git clone https://github.com/root-project/roottest.git"), check=True)
+            "git clone -o upstream https://github.com/root-project/roottest.git"), check=True)
     root_build = os.path.join(cwd, "rootbuild")
     if not os.path.exists(root_build):
         os.mkdir(root_build)

--- a/launch_build.py
+++ b/launch_build.py
@@ -9,10 +9,10 @@ from typing import Iterable
 
 def create_directories_if_necessary() -> Iterable[str]:
     cwd = os.getcwd()
-    root_home = os.path.join(cwd, "rootsrc")
+    root_home = os.path.join(cwd, "root")
     if not os.path.exists(root_home):
         subprocess.run(shlex.split(
-            "git clone https://github.com/root-project/root.git rootsrc"), check=True)
+            "git clone https://github.com/root-project/root.git"), check=True)
     if not os.path.exists(os.path.join(cwd, "roottest")):
         subprocess.run(shlex.split(
             "git clone https://github.com/root-project/roottest.git"), check=True)

--- a/step_by_step_instructions.md
+++ b/step_by_step_instructions.md
@@ -17,8 +17,8 @@ And click on the `Fork` button in the top right of the web UI.
 You can now clone both repositories on your machine, e.g. via
 
 ```bash
-$: git clone https://github.com/YOURUSERNAME/root
-$: git clone https://github.com/YOURUSERNAME/roottest
+$: git clone https://github.com/YOURUSERNAME/root.git
+$: git clone https://github.com/YOURUSERNAME/roottest.git
 ```
 
 To track changes in the main repositories, add the `upstream` remotes.
@@ -26,13 +26,13 @@ To track changes in the main repositories, add the `upstream` remotes.
 Inside the `root` directory:
 
 ```bash
-$: git remote add upstream https://github.com/root-project/root
+$: git remote add upstream https://github.com/root-project/root.git
 ```
 
 Inside the `roottest` directory:
 
 ```bash
-$: git remote add upstream https://github.com/root-project/roottest
+$: git remote add upstream https://github.com/root-project/roottest.git
 ```
 
 ## 3. Create build and install directories

--- a/step_by_step_instructions.md
+++ b/step_by_step_instructions.md
@@ -35,13 +35,13 @@ Inside the `roottest` directory:
 $: git remote add upstream https://github.com/root-project/roottest
 ```
 
-## 3. Create a build and install directories
+## 3. Create build and install directories
 
-To keep things clean, it is suggested to create a separate directory for the
-build and for the installation.
+To keep things clean, it is suggested to create separate directories for the
+builds and for the installations.
 
 ```bash
-$: mkdir mybuild myinstall
+$: mkdir rootbuild rootinstall
 ```
 
 ## 4. Configure the CMake build
@@ -51,7 +51,7 @@ For the purposes of development and testing, the following configuration is
 suggested:
 
 ```bash
-$: cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -Dtesting=ON -Droottest=ON -DCMAKE_INSTALL_PREFIX=myinstall -B mybuild -S root
+$: cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -Dtesting=ON -Droottest=ON -DCMAKE_INSTALL_PREFIX=rootinstall/myinstall -B rootbuild/mybuild -S root
 ```
 
 The process of launching the Cmake build may be sped up by using the ccache package, if it is installed in the system. To activate it, add `-Dccache=ON` to variables.
@@ -61,7 +61,7 @@ The process of launching the Cmake build may be sped up by using the ccache pack
 Finally, you can launch the CMake build via:
 
 ```bash
-$: cmake --build mybuild --target install -jNPROC
+$: cmake --build rootbuild/mybuild --target install -jNPROC
 ```
 
 Where `NPROC` is the number of available cores you want to send in parallel for the build.

--- a/step_by_step_instructions.md
+++ b/step_by_step_instructions.md
@@ -21,6 +21,20 @@ $: git clone https://github.com/YOURUSERNAME/root
 $: git clone https://github.com/YOURUSERNAME/roottest
 ```
 
+To track changes in the main repositories, add the `upstream` remotes.
+
+Inside the `root` directory:
+
+```
+$: git remote add upstream https://github.com/root-project/root
+```
+
+Inside the `roottest` directory:
+
+```
+$: git remote add upstream https://github.com/root-project/roottest
+```
+
 ## 3. Create a build and install directories
 
 To keep things clean, it is suggested to create a separate directory for the

--- a/step_by_step_instructions.md
+++ b/step_by_step_instructions.md
@@ -7,8 +7,8 @@ modifications in the form of GitHub PRs. In some cases the modifications will
 need to go in `roottest`, so it's better to clone both. Go on the respective
 websites:
 
-* https://github.com/root-project/root
-* https://github.com/root-project/roottest
+* <https://github.com/root-project/root>
+* <https://github.com/root-project/roottest>
 
 And click on the `Fork` button in the top right of the web UI.
 
@@ -16,7 +16,7 @@ And click on the `Fork` button in the top right of the web UI.
 
 You can now clone both repositories on your machine, e.g. via
 
-```
+```bash
 $: git clone https://github.com/YOURUSERNAME/root
 $: git clone https://github.com/YOURUSERNAME/roottest
 ```
@@ -25,13 +25,13 @@ To track changes in the main repositories, add the `upstream` remotes.
 
 Inside the `root` directory:
 
-```
+```bash
 $: git remote add upstream https://github.com/root-project/root
 ```
 
 Inside the `roottest` directory:
 
-```
+```bash
 $: git remote add upstream https://github.com/root-project/roottest
 ```
 
@@ -40,7 +40,7 @@ $: git remote add upstream https://github.com/root-project/roottest
 To keep things clean, it is suggested to create a separate directory for the
 build and for the installation.
 
-```
+```bash
 $: mkdir mybuild myinstall
 ```
 
@@ -50,16 +50,17 @@ There are many [configuration options](https://root.cern/install/build_from_sour
 For the purposes of development and testing, the following configuration is
 suggested:
 
-```
+```bash
 $: cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -Dtesting=ON -Droottest=ON -DCMAKE_INSTALL_PREFIX=myinstall -B mybuild -S root
 ```
+
 The process of launching the Cmake build may be sped up by using the ccache package, if it is installed in the system. To activate it, add `-Dccache=ON` to variables.
 
 ## 5. Build and install
 
 Finally, you can launch the CMake build via:
 
-```
+```bash
 $: cmake --build mybuild --target install -jNPROC
 ```
 


### PR DESCRIPTION
These changes make the installation script and the step-by-step instructions equivalent in terms of the resulting directory structure and git remote setup, the only difference being the missing fork repository and the corresponding `origin` remote in case of the automatic installation.